### PR TITLE
Fix parameter naming for pagination in getFollowers and getFollowings…

### DIFF
--- a/JxInsta/src/main/java/com/errorxcode/jxinsta/endpoints/profile/Profile.java
+++ b/JxInsta/src/main/java/com/errorxcode/jxinsta/endpoints/profile/Profile.java
@@ -154,7 +154,7 @@ public class Profile {
      * @throws InstagramException if there's an error in the Instagram API
      */
     public List<String> getFollowers(int count) throws IOException, InstagramException {
-        var req = Utils.createGetRequest("friendships/" + pk + "/followers/?count=" + count + "&maxId=" + nextPageCursor,authInfo);
+        var req = Utils.createGetRequest("friendships/" + pk + "/followers/?count=" + count + "&max_id=" + nextPageCursor,authInfo);
         try (var response = Utils.call(req,authInfo)){
             var json = new JSONObject(response.body().string());
             nextPageCursor = json.getString("next_max_id");
@@ -175,7 +175,7 @@ public class Profile {
      * @throws InstagramException if there's an error in the Instagram API
      */
     public List<String> getFollowings(int count) throws IOException, InstagramException {
-        var req = Utils.createGetRequest("friendships/" + pk + "/following/?count=" + count + "&maxId=" + nextPageCursor,authInfo);
+        var req = Utils.createGetRequest("friendships/" + pk + "/following/?count=" + count + "&max_id=" + nextPageCursor,authInfo);
         try (var response = Utils.call(req,authInfo)){
             var json = new JSONObject(response.body().string());
             nextPageCursor = json.getString("next_max_id");


### PR DESCRIPTION
Hi! 👋

I was having trouble with the API responses, I kept getting the same result when paginating 😅
So I compared the requests made by the web version and noticed a small difference in the parameter names used.

This PR updates the parameter `maxId` to the correct `max_id` in both `getFollowers` and `getFollowings` methods.

Let me know if anything else is needed.
